### PR TITLE
Debounce render loop for points leaderboard

### DIFF
--- a/pages/src/points-leaderboard.mjs
+++ b/pages/src/points-leaderboard.mjs
@@ -464,7 +464,6 @@ async function getAllSegmentResults(watching, currentEventConfig) {
     //console.log("New saved results:", savedResultsCount)
     //console.log("segment results:",segmentResults)
     //console.log("results to store:", resultsToStore)
-    await new Promise(resolve => setTimeout(resolve, 1000));
 }
 
 async function getRaceResults(watching) {
@@ -1221,7 +1220,21 @@ async function updateRacerStatus(states) {
     }
 }
 
-async function getLeaderboard(watching) {
+let _getLeaderboardBusy;
+async function getLeaderboard() {
+    if (_getLeaderboardBusy) {
+        return;
+    }
+    _getLeaderboardBusy = true;
+    try {
+        return await _getLeaderboard.apply(this, arguments);
+    } finally {
+        _getLeaderboardBusy = false;
+    }
+}
+
+
+async function _getLeaderboard(watching) {
     if (watching.state.eventSubgroupId != 0 || lastKnownSG.eventSubgroupId > 0) {        
         let refreshRate = 30000;
         if (watching.segmentData?.routeSegments) {

--- a/pages/src/segment-results-all.mjs
+++ b/pages/src/segment-results-all.mjs
@@ -416,19 +416,25 @@ async function doApproach(routeSegments,segIdx, currentLocation,watching, eventS
     doApproachRunning = false;
 }
 
-async function doInSegment(routeSegments,segIdx, currentLocation, watching, eventSubgroupId) {
+async function doInSegment() {
     if (doInSegmentRunning) {
         return;
-    } else {
-        doInSegmentRunning = true;
     }
+    doInSegmentRunning = true;
+    try {
+        return await _doInSegment.apply(this, arguments);
+    } finally {
+        doInSegmentRunning = false;
+    }
+}
+
+async function _doInSegment(routeSegments,segIdx, currentLocation, watching, eventSubgroupId) {
     if (routeSegments[segIdx].exclude) {
         infoLeftDiv.innerHTML = "";
         infoRightDiv.innerHTML = "";
         segNameDiv.innerHTML = "";
         segmentDiv.innerHTML = "";
         if (settings.transparentNoData) {document.body.classList = "transparent-bg"};
-        doInSegmentRunning = false;
         return null;
     }
     document.body.classList.remove("transparent-bg");
@@ -536,7 +542,6 @@ async function doInSegment(routeSegments,segIdx, currentLocation, watching, even
         inSegmentRefresh = Date.now();          
         const savedResultsCount = !eventSubgroupId ? 0 : await zen.storeSegmentResults(dbSegments, segmentResults, {live: liveResults});                  
     }
-    doInSegmentRunning = false;
 }
 
 async function doDeparting(routeSegments,segIdx, currentLocation, watching, eventSubgroupId) {


### PR DESCRIPTION
Make segment results debounce error-safe.

I removed the 1 second sleep in points leaderboard too cause I don't think you need it.  It's safe to hammer away there.  Let me know if that's a mistake.